### PR TITLE
set julia min versions to 0.6.0-pre

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre


### PR DESCRIPTION
for newer syntax like `abstract type`, `Base.IndexStyle`, etc
on early 0.6.0-dev versions, would be better to stay with the 0.5 version of the package