### PR TITLE
Convert AbstractVector{Int} arguments for block sizes to Vector{Int}

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -80,6 +80,13 @@ end
     end
 end
 
+
+BlockArray{T, N, R <: AbstractArray{T,N}}(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) =
+    BlockArray(R, Vector{Int}.(block_sizes)...)
+
+BlockArray{T, N}(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) =
+    BlockArray(arr, Vector{Int}.(block_sizes)...)
+
 ################################
 # AbstractBlockArray Interface #
 ################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 using BlockArrays
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
+
 
 include("test_blockindices.jl")
 include("test_blockarrays.jl")

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -127,3 +127,14 @@ end
 
 replstrmime(x) = stringmime("text/plain", x)
 @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArrays.BlockArray{Int64,2,Array{Int64,2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+
+
+@testset "AbstractVector{Int} blocks" begin
+    A = BlockArray(ones(6,6),1:3,1:3)
+    @test A[1,1] == 1
+    @test A[Block(2,3)] == ones(2,3)
+
+    A = BlockArray(Matrix{Float64},1:3,1:3)
+    A[Block(2,3)] = ones(2,3)
+    @test A[Block(2,3)] == ones(2,3)
+end


### PR DESCRIPTION
This supports the following:
```julia
A = BlockArray(ones(6,6),1:3,1:3)
```