### PR TITLE
RFC: Support views of blocks

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -22,4 +22,5 @@ Pages = ["internals.md"]
 blockindex2global
 global2blockindex
 BlockSlice
+unblock
 ```

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -21,4 +21,5 @@ Pages = ["internals.md"]
 ```@docs
 blockindex2global
 global2blockindex
+BlockSlice
 ```

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -37,7 +37,8 @@ Note that accessing an undefined block will throw an "access to undefined refere
 ## Setting and getting blocks and values
 
 A block can be set by `setblock!(block_array, v, i...)` where `v` is the array to set and `i` is the block index.
-An alternative syntax for this is `block_array[Block(i...)] = v`.
+An alternative syntax for this is `block_array[Block(i...)] = v` or
+`block_array[Block.(i)...]`.
 
 ```jldoctest
 julia> block_array = BlockArray(Matrix{Float64}, [1,2], [2,2])
@@ -72,6 +73,10 @@ A block can be retrieved with `getblock(block_array, i...)` or `block_array[Bloc
 julia> block_array[Block(1, 1)]
 1×2 Array{Float64,2}:
  1.0  2.0
+
+julia> block_array[Block(1), Block(1)]  # equivalent to above
+ 1×2 Array{Float64,2}:
+  1.0  2.0
 ```
 
 Similarly to `setblock!` this does not copy the returned array.
@@ -82,6 +87,25 @@ For setting and getting a single scalar element, the usual `setindex!` and `geti
 julia> block_array[1, 2]
 2.0
 ```
+
+## Views of blocks
+
+We can also view and modify views of blocks of `BlockArray` using the `view` syntax:
+```jldoctest
+julia> A = BlockArray(ones(6), 1:3);
+
+julia> view(A, Block(2))
+2-element SubArray{Float64,1,BlockArrays.BlockArray{Float64,1,Array{Float64,1}},Tuple{BlockArrays.BlockSlice},false}:
+ 1.0
+ 1.0
+
+julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
+2-element Array{Float64,1}:
+ 3.0
+ 4.0
+```
+
+
 
 ## Converting between `BlockArray` and normal arrays
 

--- a/docs/src/man/pseudoblockarrays.md
+++ b/docs/src/man/pseudoblockarrays.md
@@ -57,3 +57,23 @@ julia> pseudo[BlockIndex((2,1), (2,2))]
 ```
 
 The underlying array is accessed with `Array` just like for `BlockArray`.
+
+
+## Views of blocks
+
+We can also view and modify views of blocks of `PseudoBlockArray` using the `view` syntax:
+```jldoctest
+julia> A = PseudoBlockArray(ones(6), 1:3);
+
+julia> view(A, Block(2))
+2-element SubArray{Float64,1,BlockArrays.PseudoBlockArray{Float64,1,Array{Float64,1}},Tuple{BlockArrays.BlockSlice},false}:
+ 1.0
+ 1.0
+
+julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
+2-element Array{Float64,1}:
+ 3.0
+ 4.0
+```
+Note that, in memory, each block is in a BLAS-Level 3 compatible format, so
+that, in the future, algebra with blocks will be highly efficient.

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -9,8 +9,12 @@ export Block, getblock, getblock!, setblock!, nblocks, blocksize, blockcheckboun
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
-import Base: @propagate_inbounds, Array
+import Base: @propagate_inbounds, Array, to_indices, indices, unsafe_indices,
+            indices1, first, last, size, length, unsafe_length,
+            getindex, show, start, next, done, @_inline_meta, _maybetail, tail
+            
 using Base.Cartesian
+
 
 include("abstractblockarray.jl")
 
@@ -18,6 +22,7 @@ include("blocksizes.jl")
 include("blockindices.jl")
 include("blockarray.jl")
 include("pseudo_blockarray.jl")
+include("views.jl")
 include("show.jl")
 
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -9,10 +9,10 @@ export Block, getblock, getblock!, setblock!, nblocks, blocksize, blockcheckboun
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
-import Base: @propagate_inbounds, Array, to_indices, indices, unsafe_indices,
-            indices1, first, last, size, length, unsafe_length,
+import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
+            unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail
-            
+
 using Base.Cartesian
 
 

--- a/src/views.jl
+++ b/src/views.jl
@@ -1,0 +1,35 @@
+"""
+   BlockSlice(indices)
+
+Represent an AbstractUnitRange of indices that attaches a block.
+
+Upon calling `to_indices()`, Blocks are converted to BlockSlice objects to represent
+the indices over which the Block spans.
+
+This mimics the relationship between `Colon` and `Base.Slice`.
+"""
+struct BlockSlice <: AbstractUnitRange{Int}
+    block::Block{1,Int}
+    indices::UnitRange{Int}
+end
+
+for f in (:indices, :unsafe_indices, :indices1, :first, :last, :size, :length,
+          :unsafe_length, :start)
+    @eval $f(S::BlockSlice) = $f(S.indices)
+end
+
+getindex(S::BlockSlice, i::Int) = getindex(S.indices, i)
+show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")
+next(S::BlockSlice, s) = next(S.indices, s)
+done(S::BlockSlice, s) = done(S.indices, s)
+
+
+
+function unblock(block_sizes, I)
+    B = first(I)
+    BlockSlice(B,
+            first(globalrange(block_sizes,(first(B.n),))))
+end
+
+@inline to_indices(A, inds, I::Tuple{Block, Vararg{Any}}) =
+    (unblock(A.block_sizes, I), to_indices(A, _maybetail(inds), tail(I))...)

--- a/src/views.jl
+++ b/src/views.jl
@@ -25,11 +25,18 @@ done(S::BlockSlice, s) = done(S.indices, s)
 
 
 
-function unblock(block_sizes, I)
+function unblock(block_sizes::BlockSizes{N}, I::NTuple{M,Block{1,T}}) where {N, M, T}
     B = first(I)
-    BlockSlice(B,
-            first(globalrange(block_sizes,(first(B.n),))))
+    b = first(B.n)
+    # the size of the tuple I tells us how many indices have been processed
+    J = N - M + 1
+
+    range = block_sizes[J, b]:block_sizes[J, b + 1] - 1
+
+    BlockSlice(B,range)
 end
+
+to_index(::Block) = throw(ArgumentError("blocks must be converted by to_indices(...)"))
 
 @inline to_indices(A, inds, I::Tuple{Block, Vararg{Any}}) =
     (unblock(A.block_sizes, I), to_indices(A, _maybetail(inds), tail(I))...)

--- a/src/views.jl
+++ b/src/views.jl
@@ -1,5 +1,5 @@
 """
-   BlockSlice(indices)
+    BlockSlice(indices)
 
 Represent an AbstractUnitRange of indices that attaches a block.
 
@@ -24,7 +24,11 @@ next(S::BlockSlice, s) = next(S.indices, s)
 done(S::BlockSlice, s) = done(S.indices, s)
 
 
+"""
+    unblock(block_sizes, I)
 
+Returns the indices associated with a block as a `BlockSlice`.
+"""
 function unblock(block_sizes::BlockSizes{N}, I::Tuple{Block{1,T},Vararg{Any}}) where {N, T}
     B = first(I)
     b = first(B.n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,9 @@
 using BlockArrays
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
+
 
 include("test_blockindices.jl")
 include("test_blockarrays.jl")
+include("test_blockviews.jl")
 
 include("../docs/make.jl")

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -20,9 +20,30 @@
     V[1,1] = 2
     @test A[2,8] == 2
 
+    V = view(A,Block(3,2))
+    @test size(V) == (3,4)
+    V[2,1] = 3
+    @test A[5,4] == 3
+
     A = BlockArray(ones(6,6,6),1:3,1:3,1:3)
     V = view(A,Block(2),Block(3),Block(1))
     @test size(V) == (2,3,1)
     V[1,1,1] = 2
     @test A[2,4,1] == 2
+
+    V = view(A,Block(1,1,1))
+    @test size(V) == (1,1,1)
+    V[1,1,1] = 4
+    @test A[1,1,1] == 4
+
+    # blocks mimic CartesianIndex in views
+    V = view(A,Block(1,1),Block(2))
+    @test size(V) == (1,1,2)
+    V[1,1,1] = 5
+    @test A[1,1,2] == 5
+
+    V = view(A,Block(2),Block(1,1))
+    @test size(V) == (2,1,1)
+    V[1,1,1] = 6
+    @test A[2,1,1] == 6
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -1,0 +1,9 @@
+@testset "block view" begin
+    A = BlockArray(ones(6),1:3)
+    view(A, Block(2))[2] = 3.0
+    @test A[3] == 3.0
+
+    A = PseudoBlockArray(ones(6),1:3)
+    view(A, Block(2))[2] = 3.0
+    @test A[3] == 3.0
+end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -1,12 +1,32 @@
-@testset "block view" begin
+
+
+
+@testset "block slice" begin
     A = BlockArray(ones(6),1:3)
+    b = parentindexes(view(A, Block(2)))[1] # A BlockSlice
+
+    @test first(b) == 2
+    @test last(b) == 3
+    @test length(b) == 2
+    @test Base.unsafe_length(b) == 2
+    @test indices(b) == (Base.OneTo(2),)
+    @test Base.indices1(b) == Base.OneTo(2)
+    @test Base.unsafe_indices(b) == (Base.OneTo(2),)
+    @test size(b) == (2,)
+    @test collect(b) == [2,3]
+    @test b[1] == 2
+    @test b[1:2] == 2:3
+end
+
+@testset "block view" begin
+    A = BlockArray(ones(6), 1:3)
     view(A, Block(2))[2] = 3.0
     @test A[3] == 3.0
 
     # backend tests
     @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    A = PseudoBlockArray(ones(6),1:3)
+    A = PseudoBlockArray(ones(6), 1:3)
     view(A, Block(2))[2] = 3.0
     @test A[3] == 3.0
 
@@ -14,20 +34,20 @@
     # backend tests
     @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    A = BlockArray(ones(6,12),1:3,3:5)
-    V = view(A,Block(2),Block(3))
-    @test size(V) == (2,5)
+    A = BlockArray(ones(6,12), 1:3, 3:5)
+    V = view(A, Block(2), Block(3))
+    @test size(V) == (2, 5)
     V[1,1] = 2
     @test A[2,8] == 2
 
-    V = view(A,Block(3,2))
-    @test size(V) == (3,4)
+    V = view(A, Block(3, 2))
+    @test size(V) == (3, 4)
     V[2,1] = 3
     @test A[5,4] == 3
 
-    A = BlockArray(ones(6,6,6),1:3,1:3,1:3)
-    V = view(A,Block(2),Block(3),Block(1))
-    @test size(V) == (2,3,1)
+    A = BlockArray(ones(6,6,6), 1:3, 1:3, 1:3)
+    V = view(A, Block(2), Block(3), Block(1))
+    @test size(V) == (2, 3, 1)
     V[1,1,1] = 2
     @test A[2,4,1] == 2
 

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -3,7 +3,26 @@
     view(A, Block(2))[2] = 3.0
     @test A[3] == 3.0
 
+    # backend tests
+    @test_throws ArgumentError Base.to_index(A, Block(1))
+
     A = PseudoBlockArray(ones(6),1:3)
     view(A, Block(2))[2] = 3.0
     @test A[3] == 3.0
+
+
+    # backend tests
+    @test_throws ArgumentError Base.to_index(A, Block(1))
+
+    A = BlockArray(ones(6,12),1:3,3:5)
+    V = view(A,Block(2),Block(3))
+    @test size(V) == (2,5)
+    V[1,1] = 2
+    @test A[2,8] == 2
+
+    A = BlockArray(ones(6,6,6),1:3,1:3,1:3)
+    V = view(A,Block(2),Block(3),Block(1))
+    @test size(V) == (2,3,1)
+    V[1,1,1] = 2
+    @test A[2,4,1] == 2
 end


### PR DESCRIPTION
The goal of this pull request is to support, for example,

```julia
A = BlockArray(zeros(6),1:3)
view(A, Block(2))[2] = 3
A[3] == 3  # returns true
```

The approach taken is to add `BlockSlice` that represents the indices of the block, while preserving the block itself. We need to preserve the block in the `SubArray` to support efficient implementations: for example, for a `BlockArray` having access to the block makes it easy to look up the block, where resorting to a `UnitRange` of the block indices would be slow.

I'm not sure how to implement for matrices. At the moment, I'm leading towards `view(A, Block(2), Block(3))` as a canonical version, which would create a `SubArray{...,Tuple{BlockSlice,BlockSlice}}`. The case of `view(A, Block(2,3))` would fall back to this, just as `view(A, CartesianIndex(2,3))` falls back to `view(A, 2,3)`.

