### PR TITLE
Support BlockRange #23

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -21,6 +21,7 @@ Pages = ["internals.md"]
 ```@docs
 blockindex2global
 global2blockindex
+BlockRange
 BlockSlice
 unblock
 ```

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -11,7 +11,8 @@ export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrM
 
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
-            getindex, show, start, next, done, @_inline_meta, _maybetail, tail
+            getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
+            colon, broadcast, eltype
 
 using Base.Cartesian
 using Compat
@@ -23,6 +24,7 @@ include("blocksizes.jl")
 include("blockindices.jl")
 include("blockarray.jl")
 include("pseudo_blockarray.jl")
+include("blockrange.jl")
 include("views.jl")
 include("convert.jl")
 include("show.jl")

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -12,7 +12,7 @@ export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrM
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
-            colon, broadcast, eltype
+            colon, broadcast, eltype, iteratorsize
 
 using Base.Cartesian
 using Compat

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -5,6 +5,7 @@ module BlockArrays
 # AbstractBlockArray interface exports
 export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlockVecOrMat
 export Block, getblock, getblock!, setblock!, nblocks, blocksize, blockcheckbounds, BlockBoundsError, BlockIndex
+export BlockRange
 
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat

--- a/src/blockrange.jl
+++ b/src/blockrange.jl
@@ -1,0 +1,35 @@
+doc"""
+    BlockRange(startblock, stopblock)
+
+represents a cartesian range of blocks.
+
+The relationship between `Block` and `BlockRange` mimicks the relationship between
+`CartesianIndex` and `CartesianRange`.
+"""
+struct BlockRange{I<:Block}
+    start::I
+    stop::I
+end
+
+
+colon(start::Block{1}, stop::Block{1}) = BlockRange(start, stop)
+colon(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
+broadcast(::typeof(Block), range::UnitRange) = Block(first(range)):Block(last(range))
+
+eltype(::Type{BlockRange{I}}) where I = I
+eltype(::BlockRange{I}) where I = I
+
+# BlockRange behaves like CartesianRange
+for f in (:indices, :unsafe_indices, :indices1, :size, :length,
+          :unsafe_length, :start)
+    @eval $f(B::BlockRange) = $f(CartesianRange(CartesianIndex(B.start.n), CartesianIndex(B.stop.n)))
+end
+
+first(B::BlockRange) = B.start
+last(B::BlockRange) = B.stop
+
+function next(B::BlockRange, s)
+    a, b = next(CartesianRange(CartesianIndex(B.start.n), CartesianIndex(B.stop.n)), s)
+    Block(a.I), b
+end
+done(B::BlockRange, s) = done(CartesianRange(CartesianIndex(B.start.n), CartesianIndex(B.stop.n)), s)

--- a/src/blockrange.jl
+++ b/src/blockrange.jl
@@ -14,20 +14,12 @@ end
 # The following is adapted from Julia v0.7 base/multidimensional.jl
 # definition of CartesianRange
 
-BlockRange(::Tuple{}) = BlockRange{0,typeof(())}(())
+# deleted code that isn't used, such as 0-dimensional case
+
 BlockRange(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
     BlockRange{N,typeof(inds)}(inds)
 BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
     BlockRange(inds)
-BlockRange(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} =
-    BlockRange(map(r->convert(AbstractUnitRange{Int}, r), inds))
-BlockRange(inds::Vararg{AbstractUnitRange{<:Integer},N}) where {N} =
-    BlockRange(inds)
-
-BlockRange(index::Block) = BlockRange(index.n)
-BlockRange(sz::NTuple{N,<:Integer}) where {N} = BlockRange(map(Base.OneTo, sz))
-BlockRange(inds::NTuple{N,Union{<:Integer,AbstractUnitRange{<:Integer}}}) where {N} =
-    BlockRange(map(i->first(i):last(i), inds))
 
 colon(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 colon(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
@@ -59,11 +51,6 @@ end
     (start[1], newtail...)
 end
 @inline done(iter::BlockRange, state) = state.n[end] > last(iter.indices[end])
-
-# 0-d cartesian ranges are special-cased to iterate once and only once
-start(iter::BlockRange{0}) = false
-next(iter::BlockRange{0}, state) = Block(), true
-done(iter::BlockRange{0}, state) = state
 
 size(iter::BlockRange) = map(dimlength, first(iter).n, last(iter).n)
 dimlength(start, stop) = stop-start+1

--- a/src/views.jl
+++ b/src/views.jl
@@ -29,11 +29,11 @@ done(S::BlockSlice, s) = done(S.indices, s)
 
 Returns the indices associated with a block as a `BlockSlice`.
 """
-function unblock(block_sizes::BlockSizes{N}, I::Tuple{Block{1,T},Vararg{Any}}) where {N, T}
+function unblock(block_sizes::BlockSizes{N}, inds, I::Tuple{Block{1,T},Vararg{Any}}) where {N, T}
     B = first(I)
     b = first(B.n)
-    # the size of the tuple I tells us how many indices have been processed
-    M = mapreduce(B -> length(B.n), +, I)
+    # the size of inds tells us how many indices have been processed
+    M = length(inds)
     J = N - M + 1
 
     range = block_sizes[J, b]:block_sizes[J, b + 1] - 1
@@ -43,9 +43,8 @@ end
 
 to_index(::Block) = throw(ArgumentError("blocks must be converted by to_indices(...)"))
 
-
 @inline to_indices(A, inds, I::Tuple{Block{1}, Vararg{Any}}) =
-    (unblock(A.block_sizes, I), to_indices(A, _maybetail(inds), tail(I))...)
+    (unblock(A.block_sizes, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
 
 # splat out higher dimensional blocks
 # this mimics view of a CartesianIndex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,5 +10,6 @@ end
 include("test_blockindices.jl")
 include("test_blockarrays.jl")
 include("test_blockviews.jl")
+include("test_blockrange.jl")
 
 include("../docs/make.jl")

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -1,0 +1,30 @@
+@testset "block range" begin
+    @test Block(1):Block(3) == BlockArrays.BlockRange(Block(1),Block(3))
+    @test Block.(1:3) == BlockArrays.BlockRange(Block(1),Block(3))
+    @test collect(Block(1):Block(2)) == Block.([1,2])
+
+    @test_throws ArgumentError Block(1,1):Block(2,2)
+
+    A = BlockArray(collect(1:6), 1:3)
+    view(A, Block.(1:2)) == [1,2,3]
+    A[Block.(1:2)] == [1,2,3]
+
+    A = BlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
+
+
+    @test view(A, Block.(1:2), Block.(1:2)) == A[1:3,1:7]
+    @test A[Block.(1:2), Block.(1:2)] == A[1:3,1:7]
+    @test A[BlockArrays.BlockRange(Block(1,1), Block(2,2))] == A[1:3,1:7]
+
+    @test view(A, Block.(1:2), Block(1)) == A[1:3,1:3]
+    @test A[Block.(1:2), Block(1)] == A[1:3,1:3]
+
+    @test view(A, Block.(1:2), 1) == A[1:3,1]
+    @test A[Block.(1:2), 1] == A[1:3,1]
+
+    @test view(A, Block(1), Block.(1:2)) == A[1:1,1:7]
+    @test A[1, Block.(1:2)] == A[1,1:7]
+
+    B = BlockArrays.BlockRange(Block(1,1),Block(2,2))
+    @test collect(B) == [Block(1,1), Block(2,1), Block(1,2), Block(2,2)]
+end

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -1,9 +1,19 @@
 @testset "block range" begin
-    @test Block(1):Block(3) == BlockArrays.BlockRange((1:3,))
-    @test Block.(1:3) == BlockArrays.BlockRange((1:3,))
+    # test backend code
+    @test BlockRange((1:3),) == BlockRange{1,Tuple{UnitRange{Int}}}((1:3,))
+    @test BlockRange(1:3) == BlockRange((1:3),)
+    @test_throws ArgumentError Block(1,1):Block(2,2)
+
+    @test eltype(Block.(1:2)) == Block{1,Int}
+    @test eltype(typeof(Block.(1:2))) == Block{1,Int}
+    @test eltype(BlockRange{1}) == Block{1,Int}
+    @test Block(1):Block(3) == BlockRange((1:3,))
+    @test Block.(1:3) == BlockRange((1:3,))
+
     @test collect(Block(1):Block(2)) == Block.([1,2])
 
     @test_throws ArgumentError Block(1,1):Block(2,2)
+    @test_throws ArgumentError Base.to_index(Block(1):Block(2))
 
     A = BlockArray(collect(1:6), 1:3)
     view(A, Block.(1:2)) == [1,2,3]
@@ -14,7 +24,7 @@
 
     @test view(A, Block.(1:2), Block.(1:2)) == A[1:3,1:7]
     @test A[Block.(1:2), Block.(1:2)] == A[1:3,1:7]
-    @test A[BlockArrays.BlockRange((1:2,1:2))] == A[1:3,1:7]
+    @test A[BlockRange((1:2,1:2))] == A[1:3,1:7]
 
     @test view(A, Block.(1:2), Block(1)) == A[1:3,1:3]
     @test A[Block.(1:2), Block(1)] == A[1:3,1:3]
@@ -25,6 +35,6 @@
     @test view(A, Block(1), Block.(1:2)) == A[1:1,1:7]
     @test A[1, Block.(1:2)] == A[1,1:7]
 
-    B = BlockArrays.BlockRange((1:2,1:2))
+    B = BlockRange((1:2,1:2))
     @test collect(B) == [Block(1,1) Block(1,2); Block(2,1) Block(2,2)]
 end

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -1,6 +1,6 @@
 @testset "block range" begin
-    @test Block(1):Block(3) == BlockArrays.BlockRange(Block(1),Block(3))
-    @test Block.(1:3) == BlockArrays.BlockRange(Block(1),Block(3))
+    @test Block(1):Block(3) == BlockArrays.BlockRange((1:3,))
+    @test Block.(1:3) == BlockArrays.BlockRange((1:3,))
     @test collect(Block(1):Block(2)) == Block.([1,2])
 
     @test_throws ArgumentError Block(1,1):Block(2,2)
@@ -14,7 +14,7 @@
 
     @test view(A, Block.(1:2), Block.(1:2)) == A[1:3,1:7]
     @test A[Block.(1:2), Block.(1:2)] == A[1:3,1:7]
-    @test A[BlockArrays.BlockRange(Block(1,1), Block(2,2))] == A[1:3,1:7]
+    @test A[BlockArrays.BlockRange((1:2,1:2))] == A[1:3,1:7]
 
     @test view(A, Block.(1:2), Block(1)) == A[1:3,1:3]
     @test A[Block.(1:2), Block(1)] == A[1:3,1:3]
@@ -25,6 +25,6 @@
     @test view(A, Block(1), Block.(1:2)) == A[1:1,1:7]
     @test A[1, Block.(1:2)] == A[1,1:7]
 
-    B = BlockArrays.BlockRange(Block(1,1),Block(2,2))
-    @test collect(B) == [Block(1,1), Block(2,1), Block(1,2), Block(2,2)]
+    B = BlockArrays.BlockRange((1:2,1:2))
+    @test collect(B) == [Block(1,1) Block(1,2); Block(2,1) Block(2,2)]
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -2,7 +2,7 @@
 
 
 @testset "block slice" begin
-    A = BlockArray(ones(6),1:3)
+    A = BlockArray(1:6,1:3)
     b = parentindexes(view(A, Block(2)))[1] # A BlockSlice
 
     @test first(b) == 2
@@ -19,51 +19,67 @@
 end
 
 @testset "block view" begin
-    A = BlockArray(ones(6), 1:3)
-    view(A, Block(2))[2] = 3.0
-    @test A[3] == 3.0
+    A = BlockArray(collect(1:6), 1:3)
+    @test view(A, Block(2)) == [2,3]
+    view(A, Block(2))[2] = -1
+    @test A[3] == -1
 
     # backend tests
     @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    A = PseudoBlockArray(ones(6), 1:3)
-    view(A, Block(2))[2] = 3.0
-    @test A[3] == 3.0
+    A = PseudoBlockArray(collect(1:6), 1:3)
+    @test view(A, Block(2)) == [2,3]
+    view(A, Block(2))[2] = -1
+    @test A[3] == -1
 
 
     # backend tests
     @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    A = BlockArray(ones(6,12), 1:3, 3:5)
+    A = BlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
     V = view(A, Block(2), Block(3))
     @test size(V) == (2, 5)
-    V[1,1] = 2
-    @test A[2,8] == 2
+    V[1,1] = -1
+    @test A[2,8] == -1
 
     V = view(A, Block(3, 2))
     @test size(V) == (3, 4)
-    V[2,1] = 3
-    @test A[5,4] == 3
+    V[2,1] = -2
+    @test A[5,4] == -2
 
-    A = BlockArray(ones(6,6,6), 1:3, 1:3, 1:3)
+    # test mixed blocks and other indices
+    @test view(A, Block(2), 2) == [8,9]
+    @test view(A, Block(2), :) == A[2:3,:]
+
+    @test view(A, 2, Block(1)) == [2,8,14]
+    @test view(A, :, Block(1)) == A[:,1:3]
+
+    A = BlockArray(reshape(collect(1:(6^3)),6,6,6), 1:3, 1:3, 1:3)
     V = view(A, Block(2), Block(3), Block(1))
     @test size(V) == (2, 3, 1)
-    V[1,1,1] = 2
-    @test A[2,4,1] == 2
+    V[1,1,1] = -3
+    @test A[2,4,1] == -3
 
     V = view(A,Block(1,1,1))
     @test size(V) == (1,1,1)
-    V[1,1,1] = 4
-    @test A[1,1,1] == 4
+    V[1,1,1] = -4
+    @test A[1,1,1] == -4
 
     # blocks mimic CartesianIndex in views
     V = view(A,Block(1,1),Block(2))
     @test size(V) == (1,1,2)
-    V[1,1,1] = 5
-    @test A[1,1,2] == 5
+    V[1,1,1] = -5
+    @test A[1,1,2] == -5
 
     V = view(A,Block(2),Block(1,1))
     @test size(V) == (2,1,1)
-    V[1,1,1] = 6
-    @test A[2,1,1] == 6
+    V[1,1,1] = -6
+    @test A[2,1,1] == -6
+
+    # test mixed blocks and other indices
+    @test view(A, Block(1), Block(2), 1) == A[1:1,2:3,1]
+    @test view(A, Block(1,2), 1) == A[1:1,2:3,1]
+    @test view(A, Block(1), 2, 1) == A[1:1,2,1]
+    @test view(A, 1, Block(2), 1) == A[1,2:3,1]
+    @test view(A, 1, 2, Block(2)) == A[1,2,2:3]
 end


### PR DESCRIPTION
This implements `BlockRange` to represent a range of blocks, mimicking `CartesianRange`, see #23 .