### PR TITLE
Create constructor for creating allocated BlockArrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.30.0
+Compat 0.38.0

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -43,6 +43,8 @@ blockcheckbounds
 
 ```@docs
 BlockArray
+uninitialized_blocks
+UninitializedBlocks
 ```
 
 

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -43,7 +43,6 @@ blockcheckbounds
 
 ```@docs
 BlockArray
-uninitialized_BlockArray
 ```
 
 

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -43,6 +43,7 @@ blockcheckbounds
 
 ```@docs
 BlockArray
+uninitialized_BlockArray
 ```
 
 

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -23,11 +23,11 @@ We can also any other user defined array type that supports `similar`.
 
 ## Creating uninitialized `BlockArrays`.
 
-A `BlockArray` can be created with the blocks left uninitialized using the `uninitialized_BlockArray(block_type, block_sizes...)` function.
+A `BlockArray` can be created with the blocks left uninitialized using the `BlockArray(uninitialized, block_type, block_sizes...)` function.
 The `block_type` should be an array type, it could for example be `Matrix{Float64}`. The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 
 ```jldoctest
-julia> uninitialized_BlockArray(Matrix{Float32}, [1,2], [3,2])
+julia> BlockArray(uninitialized, Matrix{Float32}, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  #undef  #undef  #undef  │  #undef  #undef
  ------------------------┼----------------

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -23,11 +23,11 @@ We can also any other user defined array type that supports `similar`.
 
 ## Creating uninitialized `BlockArrays`.
 
-A `BlockArray` can be created with the blocks left uninitialized using the `BlockArrays._BlockArray(block_type, block_sizes...)` function.
+A `BlockArray` can be created with the blocks left uninitialized using the `uninitialized_BlockArray(block_type, block_sizes...)` function.
 The `block_type` should be an array type, it could for example be `Matrix{Float64}`. The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 
 ```jldoctest
-julia> BlockArrays._BlockArray(Matrix{Float32}, [1,2], [3,2])
+julia> uninitialized_BlockArray(Matrix{Float32}, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  #undef  #undef  #undef  │  #undef  #undef
  ------------------------┼----------------

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -6,13 +6,28 @@ DocTestSetup = quote
 end
 ```
 
+
+## Creating initialized `BlockArrays`
+
+A block array can be created with initialized blocks using the `BlockArray{T}(block_sizes)`
+function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
+```julia
+julia> BlockArray{Float32}([1,2], [3,2])
+2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+ 9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
+ ───────────────────────────────────────┼──────────────────────────
+ 3.28434f-21  9.37645f-26  3.28436f-21  │  8.05301f-24  9.39077f-26
+ 1.4013f-45   1.4013f-45   1.4013f-45   │  1.4013f-45   1.4013f-45
+```
+We can also any other user defined array type that supports `similar`.
+
 ## Creating uninitialized `BlockArrays`.
 
-A `BlockArray` can be created with the blocks left uninitialized using the `BlockArray(block_type, block_sizes...)` function.
-The `block_type` should be an array type, it could for example be `Matrix{Float64}`. The block sizes are each a `Vector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
+A `BlockArray` can be created with the blocks left uninitialized using the `BlockArrays._BlockArray(block_type, block_sizes...)` function.
+The `block_type` should be an array type, it could for example be `Matrix{Float64}`. The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 
 ```jldoctest
-julia> BlockArray(Matrix{Float32}, [1,2], [3,2])
+julia> BlockArrays._BlockArray(Matrix{Float32}, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  #undef  #undef  #undef  │  #undef  #undef
  ------------------------┼----------------
@@ -23,13 +38,13 @@ julia> BlockArray(Matrix{Float32}, [1,2], [3,2])
 We can also use a `SparseVector` or any other user defined array type:
 
 ```jl
-julia> BlockArray(SparseVector{Float64, Int}, [1,2])
+julia> BlockArrays._BlockArray(SparseVector{Float64, Int}, [1,2])
 2-blocked 3-element BlockArrays.BlockArray{Float64,1,SparseVector{Float64,Int64}}:
  #undef
  ------
  #undef
  #undef
-julia> BlockArray(SparseVector{Float64, Int}, [1,2])
+julia> BlockArrays._BlockArray(SparseVector{Float64, Int}, [1,2])
 ```
 
 Note that accessing an undefined block will throw an "access to undefined reference"-error.
@@ -41,7 +56,7 @@ An alternative syntax for this is `block_array[Block(i...)] = v` or
 `block_array[Block.(i)...]`.
 
 ```jldoctest
-julia> block_array = BlockArray(Matrix{Float64}, [1,2], [2,2])
+julia> block_array = BlockArrays._BlockArray(Matrix{Float64}, [1,2], [2,2])
 2×2-blocked 3×4 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
  #undef  #undef  │  #undef  #undef
  ----------------┼----------------
@@ -109,7 +124,7 @@ julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
 
 ## Converting between `BlockArray` and normal arrays
 
-An array can be repacked into a `BlockArray` with`BlockArray(array, block_sizes...)`:
+An array can be repacked into a `BlockArray` with `BlockArray(array, block_sizes...)`:
 
 ```jl
 julia> block_array_sparse = BlockArray(sprand(4, 5, 0.7), [1,3], [2,3])

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -7,12 +7,12 @@ end
 ```
 
 
-## Creating initialized `BlockArrays`
+## Creating uninitialized `BlockArrays`
 
 A block array can be created with initialized blocks using the `BlockArray{T}(block_sizes)`
 function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 ```julia
-julia> BlockArray{Float32}([1,2], [3,2])
+julia> BlockArray{Float32}(uninitialized, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
  ───────────────────────────────────────┼──────────────────────────
@@ -21,13 +21,13 @@ julia> BlockArray{Float32}([1,2], [3,2])
 ```
 We can also any other user defined array type that supports `similar`.
 
-## Creating uninitialized `BlockArrays`.
+## Creating `BlockArrays` with uninitialized blocks.
 
 A `BlockArray` can be created with the blocks left uninitialized using the `BlockArray(uninitialized, block_type, block_sizes...)` function.
 The `block_type` should be an array type, it could for example be `Matrix{Float64}`. The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 
 ```jldoctest
-julia> BlockArray(uninitialized, Matrix{Float32}, [1,2], [3,2])
+julia> BlockArray{Float32}(uninitialized_blocks, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  #undef  #undef  #undef  │  #undef  #undef
  ------------------------┼----------------
@@ -35,16 +35,16 @@ julia> BlockArray(uninitialized, Matrix{Float32}, [1,2], [3,2])
  #undef  #undef  #undef  │  #undef  #undef
 ```
 
-We can also use a `SparseVector` or any other user defined array type:
+We can also use a `SparseVector` or any other user defined array type by
+specifying it as the second argument:
 
 ```jl
-julia> BlockArray(uninitialized, SparseVector{Float64, Int}, [1,2])
+julia> BlockArray(uninitialized_blocks, SparseVector{Float64, Int}, [1,2])
 2-blocked 3-element BlockArrays.BlockArray{Float64,1,SparseVector{Float64,Int64}}:
  #undef
  ------
  #undef
  #undef
-julia> BlockArray(uninitialized, SparseVector{Float64, Int}, [1,2])
 ```
 
 Note that accessing an undefined block will throw an "access to undefined reference"-error.
@@ -56,7 +56,7 @@ An alternative syntax for this is `block_array[Block(i...)] = v` or
 `block_array[Block.(i)...]`.
 
 ```jldoctest
-julia> block_array = BlockArrays._BlockArray(Matrix{Float64}, [1,2], [2,2])
+julia> block_array = BlockArray{Float64}(unitialized_blocks, [1,2], [2,2])
 2×2-blocked 3×4 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
  #undef  #undef  │  #undef  #undef
  ----------------┼----------------

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -38,13 +38,13 @@ julia> BlockArray(uninitialized, Matrix{Float32}, [1,2], [3,2])
 We can also use a `SparseVector` or any other user defined array type:
 
 ```jl
-julia> BlockArrays._BlockArray(SparseVector{Float64, Int}, [1,2])
+julia> BlockArray(uninitialized, SparseVector{Float64, Int}, [1,2])
 2-blocked 3-element BlockArrays.BlockArray{Float64,1,SparseVector{Float64,Int64}}:
  #undef
  ------
  #undef
  #undef
-julia> BlockArrays._BlockArray(SparseVector{Float64, Int}, [1,2])
+julia> BlockArray(uninitialized, SparseVector{Float64, Int}, [1,2])
 ```
 
 Note that accessing an undefined block will throw an "access to undefined reference"-error.

--- a/docs/src/man/pseudoblockarrays.md
+++ b/docs/src/man/pseudoblockarrays.md
@@ -33,10 +33,10 @@ This "takes ownership" of the passed in array so no copy of the array is made.
 
 ## Creating initialized `BlockArrays`
 
-A block array can be created with initialized blocks using the `BlockArray{T}(block_sizes)`
+A block array can be created with uninitialized entries using the `BlockArray{T}(uninitialized, block_sizes...)`
 function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 ```julia
-julia> PseudoBlockArray{Float32}([1,2], [3,2])
+julia> PseudoBlockArray{Float32}(uninitialized, [1,2], [3,2])
 2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
  9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
  ───────────────────────────────────────┼──────────────────────────

--- a/docs/src/man/pseudoblockarrays.md
+++ b/docs/src/man/pseudoblockarrays.md
@@ -30,6 +30,21 @@ julia> pseudo = PseudoBlockArray(rand(3,3), [1,2], [2,1])
 
 This "takes ownership" of the passed in array so no copy of the array is made.
 
+
+## Creating initialized `BlockArrays`
+
+A block array can be created with initialized blocks using the `BlockArray{T}(block_sizes)`
+function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
+```julia
+julia> PseudoBlockArray{Float32}([1,2], [3,2])
+2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+ 9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
+ ───────────────────────────────────────┼──────────────────────────
+ 3.28434f-21  9.37645f-26  3.28436f-21  │  8.05301f-24  9.39077f-26
+ 1.4013f-45   1.4013f-45   1.4013f-45   │  1.4013f-45   1.4013f-45
+```
+We can also any other user defined array type that supports `similar`.
+
 ## Setting and getting blocks and values
 
 Setting and getting blocks uses the same API as `BlockArrays`. The difference here is that setting a block will update the block in place and getting a block

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -1,6 +1,8 @@
 __precompile__()
 
 module BlockArrays
+using Base.Cartesian
+using Compat
 
 # AbstractBlockArray interface exports
 export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlockVecOrMat
@@ -10,13 +12,14 @@ export BlockRange
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
+export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
+
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
             colon, broadcast, eltype, iteratorsize
 
-using Base.Cartesian
-using Compat
+
 
 
 include("abstractblockarray.jl")

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -7,7 +7,7 @@ export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlo
 export Block, getblock, getblock!, setblock!, nblocks, blocksize, blockcheckbounds, BlockBoundsError, BlockIndex
 export BlockRange
 
-export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, uninitialized_BlockArray
+export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -29,6 +29,6 @@ include("blockrange.jl")
 include("views.jl")
 include("convert.jl")
 include("show.jl")
-
+include("deprecate.jl")
 
 end # module

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -7,7 +7,7 @@ export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlo
 export Block, getblock, getblock!, setblock!, nblocks, blocksize, blockcheckbounds, BlockBoundsError, BlockIndex
 export BlockRange
 
-export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
+export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, uninitialized_BlockArray
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -47,11 +47,15 @@ function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: Ab
     _BlockArray(blocks, block_sizes)
 end
 
+@inline function uninitialized_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    _BlockArray(R, block_sizes)
+end
+
 """
 Constructs a `BlockArray` with uninitialized blocks from a block type `R` with sizes defind by `block_sizes`.
 
 ```jldoctest
-julia> uninitialized_BlockArray(Matrix{Float64}, [1,3], [2,2])
+julia> BlockArray(uninitialized, Matrix{Float64}, [1,3], [2,2])
 2×2-blocked 4×4 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
  #undef  │  #undef  #undef  #undef  │
  --------┼--------------------------┼
@@ -61,10 +65,9 @@ julia> uninitialized_BlockArray(Matrix{Float64}, [1,3], [2,2])
  #undef  │  #undef  #undef  #undef  │
 ```
 """
-function uninitialized_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    _BlockArray(R, block_sizes)
+@inline function BlockArray(::Uninitialized, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    uninitialized_BlockArray(R, block_sizes)
 end
-
 
 
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -43,7 +43,7 @@ end
 
 function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
     n_blocks = nblocks(block_sizes)
-    blocks = Array{R, N}(n_blocks)
+    blocks = Array{R, N}(uninitialized, n_blocks)
     _BlockArray(blocks, block_sizes)
 end
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -1,6 +1,49 @@
 # Note: Functions surrounded by a comment blocks are there because `Vararg` is still allocating.
 # When Vararg is fast enough, they can simply be removed.
 
+
+#######################
+# UninitializedBlocks #
+#######################
+
+"""
+    UninitializedBlocks
+
+Singleton type used in block array initialization, indicating the
+array-constructor-caller would like an uninitialized block array. See also
+uninitialized_blocks (@ref), an alias for UninitializedBlocks().
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+julia> BlockArray(uninitialized_blocks, Matrix{Float32}, [1,2], [3,2])
+2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+ #undef  #undef  #undef  │  #undef  #undef
+ ------------------------┼----------------
+ #undef  #undef  #undef  │  #undef  #undef
+ #undef  #undef  #undef  │  #undef  #undef
+"""
+struct UninitializedBlocks end
+
+"""
+    uninitialized_blocks
+
+Alias for UninitializedBlocks(), which constructs an instance of the singleton
+type UninitializedBlocks (@ref), used in block array initialization to indicate the
+array-constructor-caller would like an uninitialized block array.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+julia> BlockArray(uninitialized_blocks, Matrix{Float32}, [1,2], [3,2])
+2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+ #undef  #undef  #undef  │  #undef  #undef
+ ------------------------┼----------------
+ #undef  #undef  #undef  │  #undef  #undef
+ #undef  #undef  #undef  │  #undef  #undef
+"""
+const uninitialized_blocks = UninitializedBlocks()
+
 ##############
 # BlockArray #
 ##############
@@ -47,15 +90,15 @@ function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: Ab
     _BlockArray(blocks, block_sizes)
 end
 
-@inline function uninitialized_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    _BlockArray(R, block_sizes)
+@inline function uninitialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    _BlockArray(R, block_sizes...)
 end
 
 """
 Constructs a `BlockArray` with uninitialized blocks from a block type `R` with sizes defind by `block_sizes`.
 
 ```jldoctest
-julia> BlockArray(uninitialized, Matrix{Float64}, [1,3], [2,2])
+julia> BlockArray(uninitialized_blocks, Matrix{Float64}, [1,3], [2,2])
 2×2-blocked 4×4 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
  #undef  │  #undef  #undef  #undef  │
  --------┼--------------------------┼
@@ -65,13 +108,25 @@ julia> BlockArray(uninitialized, Matrix{Float64}, [1,3], [2,2])
  #undef  │  #undef  #undef  #undef  │
 ```
 """
-@inline function BlockArray(::Uninitialized, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    uninitialized_BlockArray(R, block_sizes)
+@inline function BlockArray(::UninitializedBlocks, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    uninitialized_blocks_BlockArray(R, block_sizes...)
+end
+
+@inline function BlockArray{T}(::UninitializedBlocks, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    BlockArray(uninitialized_blocks, Array{T,N}, block_sizes...)
+end
+
+@inline function BlockArray{T,N}(::UninitializedBlocks, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    BlockArray(uninitialized_blocks, Array{T,N}, block_sizes...)
+end
+
+@inline function BlockArray{T,N,R}(::UninitializedBlocks, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    BlockArray(uninitialized_blocks, R, block_sizes...)
 end
 
 
 
-@generated function initialized_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+@generated function initialized_blocks_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
     return quote
         block_arr = _BlockArray(R, block_sizes)
         @nloops $N i i->(1:nblocks(block_sizes, i)) begin
@@ -84,32 +139,32 @@ end
 end
 
 
-function initialized_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    initialized_BlockArray(R, BlockSizes(block_sizes...))
+function initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    initialized_blocks_BlockArray(R, BlockSizes(block_sizes...))
 end
 
-@inline function BlockArray{T}(block_sizes::BlockSizes{N}) where {T, N}
-    initialized_BlockArray(Array{T, N}, block_sizes)
+@inline function BlockArray{T}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N}
+    initialized_blocks_BlockArray(Array{T, N}, block_sizes)
 end
 
-@inline function BlockArray{T, N}(block_sizes::BlockSizes{N}) where {T, N}
-    initialized_BlockArray(Array{T, N}, block_sizes)
+@inline function BlockArray{T, N}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N}
+    initialized_blocks_BlockArray(Array{T, N}, block_sizes)
 end
 
-@inline function BlockArray{T, N, R}(block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
-    initialized_BlockArray(R, block_sizes)
+@inline function BlockArray{T, N, R}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+    initialized_blocks_BlockArray(R, block_sizes)
 end
 
-@inline function BlockArray{T}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    initialized_BlockArray(Array{T, N}, block_sizes...)
+@inline function BlockArray{T}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    initialized_blocks_BlockArray(Array{T, N}, block_sizes...)
 end
 
-@inline function BlockArray{T, N}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    initialized_BlockArray(Array{T, N}, block_sizes...)
+@inline function BlockArray{T, N}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    initialized_blocks_BlockArray(Array{T, N}, block_sizes...)
 end
 
-@inline function BlockArray{T, N, R}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    initialized_BlockArray(R, block_sizes...)
+@inline function BlockArray{T, N, R}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    initialized_blocks_BlockArray(R, block_sizes...)
 end
 
 function BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T,N}

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -40,6 +40,14 @@ end
     return exp
 end
 
+# Gives the total sizes
+@generated function Base.size(block_sizes::BlockSizes{N}) where {N}
+    exp = Expr(:tuple, [:(block_sizes[$i][end] - 1) for i in 1:N]...)
+    return quote
+        @inbounds return $exp
+    end
+end
+
 function Base.show(io::IO, block_sizes::BlockSizes{N}) where {N}
     if N == 0
         print(io, "[]")

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,0 +1,6 @@
+@deprecate BlockArray(blocks::Array{R, N}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}} BlockArrays._BlockArray(blocks, block_sizes)
+@deprecate BlockArray(blocks::Array{R, N}, block_sizes::Vararg{Vector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(blocks, block_sizes...)
+@deprecate BlockArray(blocks::Array{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(blocks, block_sizes...)
+@deprecate BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}} BlockArrays._BlockArray(R, block_sizes)
+@deprecate BlockArray(::Type{R}, block_sizes::Vararg{Vector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(R, block_sizes...)
+@deprecate BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(R, block_sizes...)

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,6 +1,4 @@
 @deprecate BlockArray(blocks::Array{R, N}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}} BlockArrays._BlockArray(blocks, block_sizes)
-@deprecate BlockArray(blocks::Array{R, N}, block_sizes::Vararg{Vector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(blocks, block_sizes...)
 @deprecate BlockArray(blocks::Array{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(blocks, block_sizes...)
 @deprecate BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}} BlockArrays._BlockArray(R, block_sizes)
-@deprecate BlockArray(::Type{R}, block_sizes::Vararg{Vector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(R, block_sizes...)
 @deprecate BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}  BlockArrays._BlockArray(R, block_sizes...)

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -61,28 +61,28 @@ PseudoBlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {
 
 
 
-@inline function PseudoBlockArray{T}(block_sizes::BlockSizes{N}) where {T, N}
+@inline function PseudoBlockArray{T}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N}
     PseudoBlockArray(similar(Array{T, N}, size(block_sizes)), block_sizes)
 end
 
-@inline function PseudoBlockArray{T, N}(block_sizes::BlockSizes{N}) where {T, N}
-    PseudoBlockArray{T}(block_sizes)
+@inline function PseudoBlockArray{T, N}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N}
+    PseudoBlockArray{T}(uninitialized, block_sizes)
 end
 
-@inline function PseudoBlockArray{T, N, R}(block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function PseudoBlockArray{T, N, R}(::Uninitialized, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
     PseudoBlockArray(similar(R, size(block_sizes)), block_sizes)
 end
 
-@inline function PseudoBlockArray{T}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    PseudoBlockArray{T}(BlockSizes(block_sizes...))
+@inline function PseudoBlockArray{T}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    PseudoBlockArray{T}(uninitialized, BlockSizes(block_sizes...))
 end
 
-@inline function PseudoBlockArray{T, N}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    PseudoBlockArray{T, N}(BlockSizes(block_sizes...))
+@inline function PseudoBlockArray{T, N}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    PseudoBlockArray{T, N}(uninitialized, BlockSizes(block_sizes...))
 end
 
-@inline function PseudoBlockArray{T, N, R}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
-    PseudoBlockArray{T, N, R}(BlockSizes(block_sizes...))
+@inline function PseudoBlockArray{T, N, R}(::Uninitialized, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    PseudoBlockArray{T, N, R}(uninitialized, BlockSizes(block_sizes...))
 end
 
 

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -60,6 +60,32 @@ PseudoBlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {
     PseudoBlockArray(blocks, Vector{Int}.(block_sizes)...)
 
 
+
+@inline function PseudoBlockArray{T}(block_sizes::BlockSizes{N}) where {T, N}
+    PseudoBlockArray(similar(Array{T, N}, size(block_sizes)), block_sizes)
+end
+
+@inline function PseudoBlockArray{T, N}(block_sizes::BlockSizes{N}) where {T, N}
+    PseudoBlockArray{T}(block_sizes)
+end
+
+@inline function PseudoBlockArray{T, N, R}(block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+    PseudoBlockArray(similar(R, size(block_sizes)), block_sizes)
+end
+
+@inline function PseudoBlockArray{T}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    PseudoBlockArray{T}(BlockSizes(block_sizes...))
+end
+
+@inline function PseudoBlockArray{T, N}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+    PseudoBlockArray{T, N}(BlockSizes(block_sizes...))
+end
+
+@inline function PseudoBlockArray{T, N, R}(block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+    PseudoBlockArray{T, N, R}(BlockSizes(block_sizes...))
+end
+
+
 ###########################
 # AbstractArray Interface #
 ###########################
@@ -68,11 +94,8 @@ function Base.similar(block_array::PseudoBlockArray{T,N}, ::Type{T2}) where {T,N
     PseudoBlockArray(similar(block_array.blocks, T2), copy(block_array.block_sizes))
 end
 
-@generated function Base.size(arr::PseudoBlockArray{T,N}) where {T,N}
-    exp = Expr(:tuple, [:(arr.block_sizes[$i][end] - 1) for i in 1:N]...)
-    return quote
-        @inbounds return $exp
-    end
+@inline function Base.size(arr::PseudoBlockArray{T,N}) where {T,N}
+    size(arr.block_sizes)
 end
 
 @inline function Base.getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Int, N}) where {T,N}

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,6 +1,7 @@
 
 import BlockArrays: _BlockArray
 
+
 @testset "block constructors" begin
     ret = BlockArray{Float64}(1:3)
     fill!(ret, 0)
@@ -13,6 +14,25 @@ import BlockArrays: _BlockArray
     ret = BlockArray{Float64,1,Vector{Float64}}(1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64}(BlockArrays.BlockSizes(1:3))
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64,1}(BlockArrays.BlockSizes(1:3))
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64,1,Vector{Float64}}(BlockArrays.BlockSizes(1:3))
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArrays._BlockArray([[0.0],[0.0,0.0],[0.0,0.0,0.0]], 1:3)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArrays._BlockArray([[0.0],[0.0,0.0],[0.0,0.0,0.0]], BlockArrays.BlockSizes(1:3))
+    @test Array(ret)  == zeros(6)
+
 
     ret = BlockArray{Float64}(1:3, 1:3)
     fill!(ret, 0)
@@ -33,6 +53,8 @@ import BlockArrays: _BlockArray
     ret = PseudoBlockArray{Float64}(1:3, 1:3)
     fill!(ret, 0)
     Matrix(ret) == zeros(6,6)
+
+    @test_throws DimensionMismatch BlockArray([1,2,3],[1,1])
 end
 
 @testset "block indexing" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -3,27 +3,27 @@ import BlockArrays: _BlockArray
 
 
 @testset "block constructors" begin
-    ret = BlockArray{Float64}(1:3)
+    ret = BlockArray{Float64}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1}(1:3)
+    ret = BlockArray{Float64,1}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1,Vector{Float64}}(1:3)
+    ret = BlockArray{Float64,1,Vector{Float64}}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64}(BlockArrays.BlockSizes(1:3))
+    ret = BlockArray{Float64}(uninitialized, BlockArrays.BlockSizes(1:3))
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1}(BlockArrays.BlockSizes(1:3))
+    ret = BlockArray{Float64,1}(uninitialized, BlockArrays.BlockSizes(1:3))
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1,Vector{Float64}}(BlockArrays.BlockSizes(1:3))
+    ret = BlockArray{Float64,1,Vector{Float64}}(uninitialized, BlockArrays.BlockSizes(1:3))
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
@@ -33,24 +33,44 @@ import BlockArrays: _BlockArray
     ret = BlockArrays._BlockArray([[0.0],[0.0,0.0],[0.0,0.0,0.0]], BlockArrays.BlockSizes(1:3))
     @test Array(ret)  == zeros(6)
 
+    ret = BlockArray{Float32}(uninitialized_blocks, 1:3)
+    @test eltype(ret.blocks) == Vector{Float32}
+    @test_throws UndefRefError ret.blocks[1]
 
-    ret = BlockArray{Float64}(1:3, 1:3)
+    ret = BlockArray{Float32,1}(uninitialized_blocks, 1:3)
+    @test eltype(ret.blocks) == Vector{Float32}
+    @test_throws UndefRefError ret.blocks[1]
+
+    ret = BlockArray{Float32,1,Vector{Float32}}(uninitialized_blocks, 1:3)
+    @test eltype(ret.blocks) == Vector{Float32}
+    @test_throws UndefRefError ret.blocks[1]
+
+    ret = BlockArray{Float32}(uninitialized_blocks, 1:3, 1:3)
+    @test eltype(ret.blocks) == Matrix{Float32}
+    @test_throws UndefRefError ret.blocks[1]
+
+    ret = BlockArray(uninitialized_blocks, Vector{Float32}, 1:3)
+    @test eltype(ret) == Float32
+    @test eltype(ret.blocks) == Vector{Float32}
+    @test_throws UndefRefError ret.blocks[1]
+
+    ret = BlockArray{Float64}(uninitialized, 1:3, 1:3)
     fill!(ret, 0)
     Matrix(ret) == zeros(6,6)
 
-    ret = PseudoBlockArray{Float64}(1:3)
+    ret = PseudoBlockArray{Float64}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = PseudoBlockArray{Float64,1}(1:3)
+    ret = PseudoBlockArray{Float64,1}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = PseudoBlockArray{Float64,1,Vector{Float64}}(1:3)
+    ret = PseudoBlockArray{Float64,1,Vector{Float64}}(uninitialized, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = PseudoBlockArray{Float64}(1:3, 1:3)
+    ret = PseudoBlockArray{Float64}(uninitialized, 1:3, 1:3)
     fill!(ret, 0)
     Matrix(ret) == zeros(6,6)
 
@@ -58,7 +78,7 @@ import BlockArrays: _BlockArray
 end
 
 @testset "block indexing" begin
-    BA_1 = _BlockArray(Vector{Float64}, [1,2,3])
+    BA_1 = BlockArray(uninitialized_blocks, Vector{Float64}, [1,2,3])
     a_1 = rand(2)
     BA_1[Block(2)] = a_1
     @test BA_1[BlockIndex(2, 1)] == a_1[1]
@@ -69,7 +89,7 @@ end
     @test_throws BlockBoundsError blockcheckbounds(BA_1, 4)
     @test_throws BlockBoundsError BA_1[Block(4)]
 
-    BA_2 = _BlockArray(Matrix{Float64}, [1,2], [3,4])
+    BA_2 = BlockArray(uninitialized_blocks, Matrix{Float64}, [1,2], [3,4])
     a_2 = rand(1,4)
     BA_2[Block(1,2)] = a_2
     @test BA_2[Block(1,2)] == a_2
@@ -226,11 +246,11 @@ end
 
 
 @testset "AbstractVector{Int} blocks" begin
-    A = BlockArray(ones(6,6),1:3,1:3)
+    A = BlockArray(ones(6,6), 1:3, 1:3)
     @test A[1,1] == 1
     @test A[Block(2,3)] == ones(2,3)
 
-    A = _BlockArray(Matrix{Float64},1:3,1:3)
+    A = BlockArray(uninitialized_blocks, Matrix{Float64}, 1:3, 1:3)
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -203,7 +203,11 @@ end
     A = BlockArray(rand(4, 5), [1,3], [2,3]);
     buf = IOBuffer()
     Base.showerror(buf, BlockBoundsError(A, (3,2)))
-    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArrays.BlockArray{Float64,2,Array{Float64,2}} at block index [3,2]"
+    if VERSION < v"0.7-"
+        @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArrays.BlockArray{Float64,2,Array{Float64,2}} at block index [3,2]"
+    else
+        @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Float64,2}} at block index [3,2]"
+    end
 end
 
 if isdefined(Base, :flatten)
@@ -214,7 +218,11 @@ end
 
 
 replstrmime(x) = stringmime("text/plain", x)
-@test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArrays.BlockArray{Int64,2,Array{Int64,2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+if VERSION < v"0.7-"
+    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArrays.BlockArray{Int64,2,Array{Int64,2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+else
+    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Int64,2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+end
 
 
 @testset "AbstractVector{Int} blocks" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,6 +1,42 @@
 
+import BlockArrays: _BlockArray
+
+@testset "block constructors" begin
+    ret = BlockArray{Float64}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64,1}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64,1,Vector{Float64}}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = BlockArray{Float64}(1:3, 1:3)
+    fill!(ret, 0)
+    Matrix(ret) == zeros(6,6)
+
+    ret = PseudoBlockArray{Float64}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = PseudoBlockArray{Float64,1}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = PseudoBlockArray{Float64,1,Vector{Float64}}(1:3)
+    fill!(ret, 0)
+    @test Array(ret)  == zeros(6)
+
+    ret = PseudoBlockArray{Float64}(1:3, 1:3)
+    fill!(ret, 0)
+    Matrix(ret) == zeros(6,6)
+end
+
 @testset "block indexing" begin
-    BA_1 = BlockArray(Vector{Float64}, [1,2,3])
+    BA_1 = _BlockArray(Vector{Float64}, [1,2,3])
     a_1 = rand(2)
     BA_1[Block(2)] = a_1
     @test BA_1[BlockIndex(2, 1)] == a_1[1]
@@ -11,7 +47,7 @@
     @test_throws BlockBoundsError blockcheckbounds(BA_1, 4)
     @test_throws BlockBoundsError BA_1[Block(4)]
 
-    BA_2 = BlockArray(Matrix{Float64}, [1,2], [3,4])
+    BA_2 = _BlockArray(Matrix{Float64}, [1,2], [3,4])
     a_2 = rand(1,4)
     BA_2[Block(1,2)] = a_2
     @test BA_2[Block(1,2)] == a_2
@@ -164,7 +200,7 @@ replstrmime(x) = stringmime("text/plain", x)
     @test A[1,1] == 1
     @test A[Block(2,3)] == ones(2,3)
 
-    A = BlockArray(Matrix{Float64},1:3,1:3)
+    A = _BlockArray(Matrix{Float64},1:3,1:3)
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end


### PR DESCRIPTION
• Support BlockArray{Float64}(1:3, 1:3), etc. syntax for creating allocated block arrays

• Deprecate BlockArray(blocks,...) in favour of _BlockArray(blocks,...) to avoid confusion with BlockArray(arr,...) function that converts arr to a BlockArray.